### PR TITLE
fix openssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repos contains the apps and config files for the 2024 edition of [Docker De
 
 ### Folders and container images
 
-- **ai-comose:** App files and Dockerfiles for Compose AI example app (coming in 2025 edition)
+- **ai-compose:** App files and Dockerfiles for Compose AI example app (coming in 2025 edition)
 - **multi-container:** DEPRECATED for 2025 edition. Compose app and app code from 2024 edition and older books
 - **multi-stage:** Very simple Go client-server app to demonstrate multi-stage builds
 - **node-app:** Node.js web server. Used for `docker init` example

--- a/ai-compose/backend/Dockerfile
+++ b/ai-compose/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-alpine@sha256:38e179a0f0436c97ecc76bcd378d7293ab3ee79e4b8c440fd
 
 # Update openssl
 RUN apk add --no-cache \
- openssl=3.3.2-r1
+ openssl=3.3.3-r0
 
 # Create a non-root user and group
 RUN addgroup -S appuser-group && adduser -D -H -G appuser-group appuser


### PR DESCRIPTION
Hi @nigelpoulton , thanks for the great book!

In chapter 9, page 218, when running 

docker compose up --detach 

I get following error:

> 
>  => [backend internal] load build context                                 0.1s
>  => => transferring context: 8.91kB                                       0.0s
>  => ERROR [backend 2/7] RUN apk add --no-cache  openssl=3.3.2-r1          1.0s
> ------                                                                         
>  > [backend 2/7] RUN apk add --no-cache  openssl=3.3.2-r1:                     
> 0.194 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz                                                                           
> 0.559 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz
> 0.871 ERROR: unable to select packages:
> 0.873   openssl-3.3.3-r0:
> 0.873     breaks: world[openssl=3.3.2-r1]
> ------
> failed to solve: process "/bin/sh -c apk add --no-cache  openssl=3.3.2-r1" did not complete successfully: exit code: 1

Updating openssl to 3.3.3-r0 fixed the issue.

Also, fixed minor typo (comose => compose).

Thanks

 