### PR TITLE
Update .env file to correct the MODEL_HOST URL because it is missing the TCP port 12434. 

### DIFF
--- a/dmr/.env
+++ b/dmr/.env
@@ -1,5 +1,5 @@
 # Configuration for the LLM service
-MODEL_HOST=http://model-runner.docker.internal/engines/v1
+MODEL_HOST=http://model-runner.docker.internal:12434/engines/v1
 
 # Which model to use
 LLM_MODEL_NAME=ai/mistral:7B-Q4_K_M


### PR DESCRIPTION
Corrected the MODEL_HOST URL to include the TCP port number 12434. Without the TCP port the "AI Chatbot on Docker Model Runner" from chapter "Use Docker Model Runner with Compose" is not working.